### PR TITLE
Ensures workflow only runs on tag creation or pull requests, instead of every creation event

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Build firmware
     steps:
       - name: Check out this repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build Docker image
         run: docker compose build --pull --build-arg APT_MIRROR="http://azure.archive.ubuntu.com/ubuntu/"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
           path: build/prawnblaster/*.uf2
 
       - name: Create release
-        if: ${{ github.event.ref_type == 'tag' }}
+        if: (github.event_name == 'push' && contains(github.ref, '/tags'))
         uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,7 @@
 name: Build firmware
 
 on:
-  create:
+  push:
     tags:
       - '[0-9]+\.[0-9]+\.[0-9]+*'
   pull_request:


### PR DESCRIPTION
Noticed this working on another project. The `create` tag doesn't support `tag` filtering. It fails silently and just runs the workflow for any create event, which is most things like branch creation. It should actually be a `push` event which does support tag filtering.