### PR TITLE
Add logic tree for conditional voltage setting based on freq request

### DIFF
--- a/prawnblaster/CMakeLists.txt
+++ b/prawnblaster/CMakeLists.txt
@@ -38,12 +38,6 @@ else ()
     message(FATAL_ERROR "Unsupported PICO_BOARD")
 endif()
 
-
-# Pass in overclock state to firmware as a compiler definition
-if(overclock)
-    target_compile_definitions(${firmware_name} PUBLIC "PRAWNBLASTER_OVERCLOCK=1")
-endif()
-
 # Pull in our pico_stdlib which aggregates commonly used features
 target_link_libraries(${firmware_name} pico_stdlib hardware_pio pico_multicore pico_unique_id hardware_clocks hardware_dma hardware_vreg tinyusb_device tinyusb_board)
 target_include_directories(${firmware_name} PRIVATE .)

--- a/prawnblaster/CMakeLists.txt
+++ b/prawnblaster/CMakeLists.txt
@@ -1,49 +1,52 @@
-set(overclocks 0;1)
+# Compute firmware name
+set(firmware_name prawnblaster)
+if(PICO_PLATFORM MATCHES "^rp2350")
+    set(firmware_name "${firmware_name}_rp2350")
+else()
+    set(firmware_name "${firmware_name}_${PICO_PLATFORM}")
+endif()
+# if(overclock)
+#     set(firmware_name "${firmware_name}_overclock")
+# endif()
 
-foreach (overclock IN LISTS overclocks)
-    # Compute firmware name
-    set(firmware_name prawnblaster)
-    if(PICO_PLATFORM MATCHES "^rp2350")
-        set(firmware_name "${firmware_name}_rp2350")
-    else()
-        set(firmware_name "${firmware_name}_${PICO_PLATFORM}")
-    endif()
-    if(overclock)
-        set(firmware_name "${firmware_name}_overclock")
-    endif()
+add_executable(${firmware_name} prawnblaster.cpp fast_serial.c)
 
-    add_executable(${firmware_name} prawnblaster.cpp fast_serial.c)
+pico_generate_pio_header(${firmware_name} ${CMAKE_CURRENT_LIST_DIR}/pseudoclock.pio)
 
-    pico_generate_pio_header(${firmware_name} ${CMAKE_CURRENT_LIST_DIR}/pseudoclock.pio)
+# Pass in number of instructions to firmware as a compiler definition
+set(num_instructions 30000)
 
-    # Pass in number of instructions to firmware as a compiler definition
-    set(num_instructions 30000)
-    if(PICO_PLATFORM MATCHES "^rp2350")
-        set(num_instructions 60000)
-    endif()
-    target_compile_definitions(${firmware_name} PUBLIC "PRAWNBLASTER_NUM_INSTRUCTIONS=${num_instructions}")
+# Pass in freq limits to firmware in MHz
+set(normal_freq_limit 133)
+set(overclock_freq_limit 200)
 
-    # Pass in board type to firmware as a compiler definition. Note that PICO_BOARD is passed in by the SDK, but it's passed in a string which isn't valid and so I can't use it...
-    # This is also, to some extent, a duplicate of the above PRAWNBLASTER_NUM_INSTRUCTIONS but I think it makes sense to keep these seperate.
-    if (PICO_BOARD STREQUAL "pico")
-        target_compile_definitions(${firmware_name} PUBLIC "PRAWNBLASTER_PICO_BOARD=1")
-    elseif (PICO_BOARD STREQUAL "pico2")
-        target_compile_definitions(${firmware_name} PUBLIC "PRAWNBLASTER_PICO_BOARD=2")
-    else ()
-        message(FATAL_ERROR "Unsupported PICO_BOARD")
-    endif()
-    
+if(PICO_PLATFORM MATCHES "^rp2350")
+    set(num_instructions 60000)
+    set(normal_freq_limit 150)
+endif()
+target_compile_definitions(${firmware_name} PUBLIC "PRAWNBLASTER_NUM_INSTRUCTIONS=${num_instructions}")
+target_compile_definitions(${firmware_name} PUBLIC "PRAWNBLASTER_NORMAL_FREQ_LIMIT=${normal_freq_limit}")
+target_compile_definitions(${firmware_name} PUBLIC "PRAWNBLASTER_OVERCLOCK_FREQ_LIMIT=${overclock_freq_limit}")
 
-    # Pass in overclock state to firmware as a compiler definition
-    if(overclock)
-        target_compile_definitions(${firmware_name} PUBLIC "PRAWNBLASTER_OVERCLOCK=1")
-    endif()
+# Pass in board type to firmware as a compiler definition. Note that PICO_BOARD is passed in by the SDK, but it's passed in a string which isn't valid and so I can't use it...
+# This is also, to some extent, a duplicate of the above PRAWNBLASTER_NUM_INSTRUCTIONS but I think it makes sense to keep these seperate.
+if (PICO_BOARD STREQUAL "pico")
+    target_compile_definitions(${firmware_name} PUBLIC "PRAWNBLASTER_PICO_BOARD=1")
+elseif (PICO_BOARD STREQUAL "pico2")
+    target_compile_definitions(${firmware_name} PUBLIC "PRAWNBLASTER_PICO_BOARD=2")
+else ()
+    message(FATAL_ERROR "Unsupported PICO_BOARD")
+endif()
 
-    # Pull in our pico_stdlib which aggregates commonly used features
-    target_link_libraries(${firmware_name} pico_stdlib hardware_pio pico_multicore pico_unique_id hardware_clocks hardware_dma hardware_vreg tinyusb_device tinyusb_board)
-    target_include_directories(${firmware_name} PRIVATE .)
 
-    # create map/bin/hex/uf2 file etc.
-    pico_add_extra_outputs(${firmware_name})
-        
-endforeach()
+# Pass in overclock state to firmware as a compiler definition
+if(overclock)
+    target_compile_definitions(${firmware_name} PUBLIC "PRAWNBLASTER_OVERCLOCK=1")
+endif()
+
+# Pull in our pico_stdlib which aggregates commonly used features
+target_link_libraries(${firmware_name} pico_stdlib hardware_pio pico_multicore pico_unique_id hardware_clocks hardware_dma hardware_vreg tinyusb_device tinyusb_board)
+target_include_directories(${firmware_name} PRIVATE .)
+
+# create map/bin/hex/uf2 file etc.
+pico_add_extra_outputs(${firmware_name})

--- a/prawnblaster/prawnblaster.cpp
+++ b/prawnblaster/prawnblaster.cpp
@@ -37,11 +37,7 @@ extern "C"{
 #include "fast_serial.h"
 }
 
-#ifndef PRAWNBLASTER_OVERCLOCK
 const char VERSION[16] = "1.2.0";
-#else
-const char VERSION[16] = "1.2.0-overclock";
-#endif //PRAWNBLASTER_OVERCLOCK
 
 int DEBUG;
 

--- a/prawnblaster/prawnblaster.cpp
+++ b/prawnblaster/prawnblaster.cpp
@@ -45,6 +45,10 @@ const char VERSION[16] = "1.2.0-overclock";
 
 int DEBUG;
 
+// Freq limits in MHz
+constexpr unsigned int normal_freq_limit = PRAWNBLASTER_NORMAL_FREQ_LIMIT;
+constexpr unsigned int overclock_freq_limit = PRAWNBLASTER_OVERCLOCK_FREQ_LIMIT;
+
 // Can't seem to have this be used to define array size even though it's a constant
 constexpr unsigned int max_instructions = PRAWNBLASTER_NUM_INSTRUCTIONS;
 constexpr unsigned int instruction_array_size = 2 * max_instructions + 8;
@@ -1038,13 +1042,17 @@ void loop()
         }
         else
         {
-            if (freq >= 150 * MHZ)
+            if (freq > overclock_freq_limit * MHZ)
             {
-                    vreg_set_voltage(VREG_VOLTAGE_1_30);
-                }
-                if (freq < 150 * MHZ)
-                {
-                    vreg_set_voltage(VREG_VOLTAGE_1_10);
+                fast_serial_printf("WARNING: Requested freq > normal bounds, setting voltage = 1.3 V\n");
+                vreg_set_voltage(VREG_VOLTAGE_1_30);
+            }
+            else if (freq > normal_freq_limit * MHZ && freq <= overclock_freq_limit * MHZ)
+            {
+                vreg_set_voltage(VREG_VOLTAGE_1_20);
+            }
+            else {
+                vreg_set_voltage(VREG_VOLTAGE_1_10);
             }
             if (DEBUG)
             {
@@ -1056,21 +1064,6 @@ void loop()
             }
             else
             {
-
-#ifndef PRAWNBLASTER_OVERCLOCK
-#    if PRAWNBLASTER_PICO_BOARD == 1
-                if (freq > 200 * MHZ)
-#    elif PRAWNBLASTER_PICO_BOARD == 2
-                if (freq > 150 * MHZ)
-#    else
-#        error "Unsupported PICO_BOARD"
-#    endif // PICO_BOARD
-                // Do validation checking on values provided
-                {
-                    fast_serial_printf("Invalid clock frequency specified\r\n");
-                    return;
-                }
-#endif //PRAWNBLASTER_OVERCLOCK
 
                 // Set new clock frequency
                 if (src == 0)


### PR DESCRIPTION
PR to add the overclock logic detailed here:
https://github.com/labscript-suite/PrawnBlaster/issues/34#issuecomment-3207666451

This will also warn the user in `setclock` if they request a frequency that's considered overclocking (currently >200 MHz). I tested with both rp2040 and rp2350 prawnblasters.